### PR TITLE
Add `updateGroup` and `removeGroup` endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "typescript": "^5.3.3"
     },
     "dependencies": {
-        "@bandada/api-sdk": "^2.2.2",
+        "@bandada/api-sdk": "2.2.6",
         "chalk": "^4",
         "figlet": "^1.7.0",
         "node-emoji": "^2.1.3"

--- a/src/bandada-sdk.ts
+++ b/src/bandada-sdk.ts
@@ -66,6 +66,30 @@ async function main() {
     log(`   Credentials: ${bandadaPrimaryBold(credentials)}`)
 
     /**
+     * updateGroup
+     * Updates a specific group.
+     */
+    const updatedGroupData = await apiSdk.updateGroup(
+        groupId,
+        {
+            description: "This is an off-chain Bandada group (upgraded 🚀)",
+            treeDepth: 32,
+            fingerprintDuration: 7200
+        },
+        adminApiKey
+    )
+    log(`\nUpdated Group data:`)
+    log(`   Id: ${bandadaPrimaryBold(updatedGroupData.id)}`)
+    log(`   Name: ${bandadaPrimaryBold(updatedGroupData.name)}`)
+    log(`   Description: ${bandadaPrimaryBold(updatedGroupData.description)}`)
+    log(`   Admin: ${bandadaPrimaryBold(updatedGroupData.admin)}`)
+    log(`   Tree depth: ${bandadaPrimaryBold(updatedGroupData.treeDepth)}`)
+    log(`   Fingerprint duration: ${bandadaPrimaryBold(updatedGroupData.fingerprintDuration)}`)
+    log(`   Created at: ${bandadaPrimaryBold(updatedGroupData.createdAt)}`)
+    log(`   Members: ${bandadaPrimaryBold(updatedGroupData.members.length === 0 ? "[]" : updatedGroupData.members)}`)
+    log(`   Credentials: ${bandadaPrimaryBold(updatedGroupData.credentials)}`)
+
+    /**
      * addMemberByApiKey
      * Adds a member to a group using an API Key.
      */
@@ -129,8 +153,17 @@ async function main() {
     log(`Removing members [${bandadaPrimaryBold(membersIdsToRemove)}] using an API Key`)
     log(`Group members: ${bandadaPrimaryBold(`[${(await apiSdk.getGroup(groupId)).members}]`)}\n`)
 
+    /**
+     * removeGroup
+     * Deletes a group.
+     */
+    await apiSdk.removeGroups([groupId], adminApiKey)
+
+    log(`Removing the group [${bandadaPrimaryBold(groupId)}] using an API Key`)
+    log(`Group [${bandadaPrimaryBold(groupId)}] successfully removed using an API Key`)
+
     log(
-        `${cloudEmoji}  You have ${bandadaPrimaryBold("successfully")} interacted with ${bandadaPrimaryBold("Bandada SDK")} ${cloudEmoji}`
+        `\n${cloudEmoji}  You have ${bandadaPrimaryBold("successfully")} interacted with ${bandadaPrimaryBold("Bandada SDK")} ${cloudEmoji}`
     )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,18 +12,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bandada/api-sdk@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@bandada/api-sdk@npm:2.2.2"
+"@bandada/api-sdk@npm:2.2.6":
+  version: 2.2.6
+  resolution: "@bandada/api-sdk@npm:2.2.6"
   dependencies:
-    "@bandada/utils": "npm:2.2.2"
-  checksum: 10c0/ce1ea1f15637c8d9dcc842494e920cb48f9be987ccde34818b743fb26df513e264d122901728b869e9e0dd86f0c5b99f137bda8467d3dedda0e998027a65bdc0
+    "@bandada/utils": "npm:2.2.6"
+  checksum: 10c0/ba37271d3819e8367c5358b548ec5b132f8bbc1fdc168fe092780ff23ea5b944ed14b9ddeec1e07df87ff03c7bc2e8e3095e1e38a09d119fa183cc9b48c66830
   languageName: node
   linkType: hard
 
-"@bandada/utils@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@bandada/utils@npm:2.2.2"
+"@bandada/utils@npm:2.2.6":
+  version: 2.2.6
+  resolution: "@bandada/utils@npm:2.2.6"
   dependencies:
     "@ethersproject/abstract-signer": "npm:^5.7.0"
     "@ethersproject/address": "npm:^5.7.0"
@@ -32,7 +32,7 @@ __metadata:
     "@ethersproject/strings": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
     axios: "npm:^1.3.3"
-  checksum: 10c0/c7f470335dbbb9f8ab485233fc53c4c5dd60b8eb13889819249e3bc873de9aa4173e705d2e557ea29a6b3338422908b411de6e0fc3589c3ff2dda3f46d6434a4
+  checksum: 10c0/fc99b8e63db9da0abeec35d69292a0e90a06577f4917670e82a96a80b158875f1b7c8c0db916affd0800503f23db64d94e3a45b5a46c832eb61893e6fd7a794f
   languageName: node
   linkType: hard
 
@@ -934,7 +934,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "bandada-nodejs@workspace:."
   dependencies:
-    "@bandada/api-sdk": "npm:^2.2.2"
+    "@bandada/api-sdk": "npm:2.2.6"
     "@types/figlet": "npm:^1.5.8"
     "@types/node": "npm:^20.10.6"
     "@typescript-eslint/eslint-plugin": "npm:^6.18.0"


### PR DESCRIPTION
This PR adds the `updateGroup` and `removeGroup` endpoints to the demonstrative script using the latest Bandada API SDK version (v.2.2.6).

This has been tested with prod, staging and dev.